### PR TITLE
76 combine enable location and push notification buttons

### DIFF
--- a/TransACT/Managers/FirebaseManager.swift
+++ b/TransACT/Managers/FirebaseManager.swift
@@ -1,6 +1,6 @@
 //
 //  FirebaseManager.swift
-//  VIPapplication
+//  TransACT
 //
 //  Created by Braeden Meikle on 3/26/22.
 //

--- a/TransACT/Managers/LocationManager.swift
+++ b/TransACT/Managers/LocationManager.swift
@@ -1,6 +1,6 @@
 //
 //  LocationManager.swift
-//  VIPapplication
+//  TransACT
 //
 //  Created by Shuangyue Cheng on 2/28/22.
 //

--- a/TransACT/Managers/LoginManager.swift
+++ b/TransACT/Managers/LoginManager.swift
@@ -1,6 +1,6 @@
 //
 //  LoginManager.swift
-//  VIPapplication
+//  TransACT
 //
 //  Created by Braeden Meikle on 3/26/22.
 //

--- a/TransACT/Managers/NotificationManager.swift
+++ b/TransACT/Managers/NotificationManager.swift
@@ -1,6 +1,6 @@
 //
 //  NotificationManager.swift
-//  VIPapplication
+//  TransACT
 //
 //  Created by Shuangyue Cheng on 2/28/22.
 //

--- a/TransACT/View/UserPermissionsView.swift
+++ b/TransACT/View/UserPermissionsView.swift
@@ -14,6 +14,8 @@ struct UserPermissionsView: View {
     //@ObservedObject var notificationManager = NotificationManager.shared
     //@AppStorage("NotificationPushInitialRequest") var initialRequestDone: Bool = false
     @State private var showPopup: Bool = false
+    @State private var enabledPushNotif: Bool = false
+    @State private var enabledLocation: Bool = false
     
     /*func passUserToLocationManager() {
         locationManager.setUser(user: user)
@@ -27,6 +29,7 @@ struct UserPermissionsView: View {
                 // Handle the error here.
             }
             
+            enabledPushNotif = true
             // Enable or disable features based on the authorization.
         }
     }
@@ -41,6 +44,12 @@ struct UserPermissionsView: View {
         }*/
         
         VStack {
+            
+            if enabledLocation && enabledPushNotif {
+                // go to MainTabView
+                NavigationLink(destination: MainTabView(), label: {})
+            }
+            
             Spacer().frame(height: 30)
             Text("Share location data and allow push notifications")
                 .font(.custom("PTMono-Bold", size: 18))

--- a/TransACT/View/UserPermissionsView.swift
+++ b/TransACT/View/UserPermissionsView.swift
@@ -10,12 +10,25 @@ import SwiftUI
 struct UserPermissionsView: View {
     
     @EnvironmentObject var user: User
-    @ObservedObject var locationManager = LocationManager.shared
-    @ObservedObject var notificationManager = NotificationManager.shared
-    @AppStorage("NotificationPushInitialRequest") var initialRequestDone: Bool = false
+    //@ObservedObject var locationManager = LocationManager.shared
+    //@ObservedObject var notificationManager = NotificationManager.shared
+    //@AppStorage("NotificationPushInitialRequest") var initialRequestDone: Bool = false
+    @State private var showPopup: Bool = false
     
-    func passUserToLocationManager() {
+    /*func passUserToLocationManager() {
         locationManager.setUser(user: user)
+    }*/
+    
+    func requestPushNotif() {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            
+            if error != nil {
+                // Handle the error here.
+            }
+            
+            // Enable or disable features based on the authorization.
+        }
     }
     
     var body: some View {
@@ -28,57 +41,68 @@ struct UserPermissionsView: View {
         }*/
         
         VStack {
-            Image("LocationSharing")
-                .resizable()
-                .frame(width: 300, height: 200)
             Spacer().frame(height: 30)
             Text("Share location data and allow push notifications")
-                .font(.custom("PTMono-Bold", size: 30))
+                .font(.custom("PTMono-Bold", size: 18))
                 .multilineTextAlignment(.center)
             Spacer().frame(height: 30)
-            // [Learn more about this requirement.](https://www.apple.com)
-            /*Text("This app collects location services to understand the congestion distribution. By enabling the location, you are providing access to Georgia Tech researchers to use the data for future studies. You can opt out of the study at any time.")
-                .font(.custom("Ramaraja", size: 19))
-                .multilineTextAlignment(.leading)
-                .frame(width: 300, height: 200, alignment: .topLeading)*/
-            /*Text("Get push notifications for available incentives, research updates and other activities going on! [Learn more about this requirement.](https://www.apple.com)")
-                .font(.custom("Ramaraja", size: 20))
-                .multilineTextAlignment(.leading)
-                .frame(width: 300, height: 140, alignment: .leading)*/
-            
-            Button(action: {
-                locationManager.requestLocation()
-                passUserToLocationManager()
-                // UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-            }, label: {
-                ZStack {
-                    Rectangle()
-                        .fill(Color.green)
-                        .frame(width: 282, height: 50)
-                    Text("Enable location")
-                        .font(.custom("PTMono-Bold", size: 18))
-                        .foregroundColor(.white)
-                }
-            })
-            Button(action: {
-                notificationManager.requestAuthorization()
-                initialRequestDone = true
-                // UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-            }, label: {
-                ZStack {
-                    Rectangle()
-                        .fill(Color.green)
-                        .frame(width: 282, height: 50)
-                    Text("Enable notifications")
-                        .font(.custom("PTMono-Bold", size: 18))
-                        .foregroundColor(.white)
-                }
-            })
+            Group {
+                Button(action: {
+                    //locationManager.requestLocation()
+                    //passUserToLocationManager()
+                    // UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                    /*
+                     
+                     for location:
+                     https://developer.apple.com/documentation/corelocation/requesting_authorization_for_location_services
+                     ->NSLocationWhenInUsageDescription Key
+                     https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationwheninuseusagedescription
+                     https://stackoverflow.com/questions/46193797/nslocationwheninuseusagedescription-warning-but-i-have-already-added-it
+                     
+                     
+                     
+                     */
+                }, label: {
+                    ZStack {
+                        Rectangle()
+                            .fill(Color.green)
+                            .frame(width: 282, height: 50)
+                        Text("Enable location")
+                            .font(.custom("PTMono-Bold", size: 18))
+                            .foregroundColor(.white)
+                    }
+                })
+                Button(action: {
+                    //notificationManager.requestAuthorization()
+                    //initialRequestDone = true
+                    // UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                    requestPushNotif()
+                }, label: {
+                    ZStack {
+                        Rectangle()
+                            .fill(Color.green)
+                            .frame(width: 282, height: 50)
+                        Text("Enable notifications")
+                            .font(.custom("PTMono-Bold", size: 18))
+                            .foregroundColor(.white)
+                    }
+                })
+            }
             Spacer().frame(height: 20)
-            NavigationLink(destination: MainTabView()) {
-                Text("Skip for now")
-                    .font(.custom("PTMono-Regular", size: 18))
-                    .foregroundColor(.black)
+            Group {
+                NavigationLink(destination: MainTabView()) {
+                    Text("Skip for now")
+                        .font(.custom("PTMono-Regular", size: 18))
+                        .foregroundColor(.black)
+                }
+                Spacer().frame(height: 20)
+                Button(action: {
+                    showPopup = true
+                }, label: {
+                    Text("Why am I seeing this?").font(.custom("PTMono-Regular", size: 18))
+                }).popover(isPresented: $showPopup, content: {
+                    PopupView()
+                })
             }
             Spacer().frame(height: 40)
             HStack(spacing: 50) {
@@ -96,6 +120,26 @@ struct UserPermissionsView: View {
         }
             .navigationBarHidden(true)
             .environmentObject(user)
+    }
+}
+
+struct PopupView: View {
+    
+    var body: some View {
+        VStack {
+            Image("LocationSharing")
+                .resizable()
+                .frame(width: 300, height: 200)
+            // [Learn more about this requirement.](https://www.apple.com)
+            Text("This app collects location services to understand the congestion distribution. By enabling the location, you are providing access to Georgia Tech researchers to use the data for future studies. You can opt out of the study at any time.")
+                .font(.custom("Ramaraja", size: 20))
+                .multilineTextAlignment(.leading)
+                .frame(width: 300, height: 200, alignment: .topLeading)
+            Text("Get push notifications for available incentives, research updates and other activities going on! [Learn more about this requirement.](https://www.apple.com)")
+                .font(.custom("Ramaraja", size: 20))
+                .multilineTextAlignment(.leading)
+                .frame(width: 300, height: 140, alignment: .leading)
+        }
     }
 }
 

--- a/TransACT/View/UserPermissionsView.swift
+++ b/TransACT/View/UserPermissionsView.swift
@@ -10,18 +10,18 @@ import SwiftUI
 struct UserPermissionsView: View {
     
     @EnvironmentObject var user: User
-    //@ObservedObject var locationManager = LocationManager.shared
-    //@ObservedObject var notificationManager = NotificationManager.shared
-    //@AppStorage("NotificationPushInitialRequest") var initialRequestDone: Bool = false
+    @ObservedObject var locationManager = LocationManager.shared
+    @ObservedObject var notificationManager = NotificationManager.shared
+    
     @State private var showPopup: Bool = false
-    @State private var enabledPushNotif: Bool = false
-    @State private var enabledLocation: Bool = false
+    //@State private var initLocReq: Bool = false
+    //@AppStorage("NotificationPushInitialRequest") var initNotifReq: Bool = false
     
     /*func passUserToLocationManager() {
         locationManager.setUser(user: user)
     }*/
     
-    func requestPushNotif() {
+    /*func requestPushNotif() {
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
             
@@ -32,23 +32,22 @@ struct UserPermissionsView: View {
             enabledPushNotif = true
             // Enable or disable features based on the authorization.
         }
-    }
+    }*/
     
     var body: some View {
-        
-        /*if locationManager.userLocation != nil {
-            // if user denied -> userLocation is nil
-            UserPermissionsView().task {
-                passUserToLocationManager()
-            }
-        }*/
-        
         VStack {
             
-            if enabledLocation && enabledPushNotif {
-                // go to MainTabView
+            /*if initLocReq && initNotifReq {
+                // asked for permissions, go to MainTabView
                 NavigationLink(destination: MainTabView(), label: {})
-            }
+            }*/
+            
+            /*if locationManager.userLocation != nil {
+                // if user denied -> userLocation is nil
+                UserPermissionsView().task {
+                    passUserToLocationManager()
+                }
+            }*/
             
             Spacer().frame(height: 30)
             Text("Share location data and allow push notifications")
@@ -57,19 +56,17 @@ struct UserPermissionsView: View {
             Spacer().frame(height: 30)
             Group {
                 Button(action: {
-                    //locationManager.requestLocation()
+                    locationManager.requestLocation()
                     //passUserToLocationManager()
+                    //initLocReq = true
+                    
                     // UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
                     /*
-                     
                      for location:
                      https://developer.apple.com/documentation/corelocation/requesting_authorization_for_location_services
                      ->NSLocationWhenInUsageDescription Key
                      https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationwheninuseusagedescription
                      https://stackoverflow.com/questions/46193797/nslocationwheninuseusagedescription-warning-but-i-have-already-added-it
-                     
-                     
-                     
                      */
                 }, label: {
                     ZStack {
@@ -82,10 +79,9 @@ struct UserPermissionsView: View {
                     }
                 })
                 Button(action: {
-                    //notificationManager.requestAuthorization()
-                    //initialRequestDone = true
-                    // UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-                    requestPushNotif()
+                    notificationManager.requestAuthorization()
+                    //initNotifReq = true
+                    //requestPushNotif()
                 }, label: {
                     ZStack {
                         Rectangle()
@@ -122,10 +118,6 @@ struct UserPermissionsView: View {
                     .resizable()
                     .frame(width: 90.0, height: 90.0)
             }
-            
-            /*if initialRequestDone {
-                NavigationLink(destination: MainTabView(), label: {})
-            }*/
         }
             .navigationBarHidden(true)
             .environmentObject(user)
@@ -133,13 +125,11 @@ struct UserPermissionsView: View {
 }
 
 struct PopupView: View {
-    
     var body: some View {
         VStack {
             Image("LocationSharing")
                 .resizable()
                 .frame(width: 300, height: 200)
-            // [Learn more about this requirement.](https://www.apple.com)
             Text("This app collects location services to understand the congestion distribution. By enabling the location, you are providing access to Georgia Tech researchers to use the data for future studies. You can opt out of the study at any time.")
                 .font(.custom("Ramaraja", size: 20))
                 .multilineTextAlignment(.leading)
@@ -147,7 +137,7 @@ struct PopupView: View {
             Text("Get push notifications for available incentives, research updates and other activities going on! [Learn more about this requirement.](https://www.apple.com)")
                 .font(.custom("Ramaraja", size: 20))
                 .multilineTextAlignment(.leading)
-                .frame(width: 300, height: 140, alignment: .leading)
+                .frame(width: 300, height: 200, alignment: .topLeading)
         }
     }
 }


### PR DESCRIPTION
- Does not fix the location and push notification buttons
- Combines the two views for requesting push notifications and requesting location use
- Adds a popup explaining why we want/need the data if the user clicks "Why am I seeing this?"
- Reduces the amount of views/clunkiness and improves overall fluidity of the app by combining the two views
- Will need to fix the buttons however
- Did some research on my own for how to request location and notifications but they did not work for whatever reason, and my code is still there (found on apple developer website) but it is commented out since it does not work